### PR TITLE
Bump ps-client from 5.1.2 to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "showdown-tests",
       "dependencies": {
         "fast-cartesian": "^9.0.1",
-        "ps-client": "^5.1.2"
+        "ps-client": "^5.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.8.1"
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/ps-client": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/ps-client/-/ps-client-5.1.2.tgz",
-      "integrity": "sha512-0G0ZPPu2tsPzSHNqywKNU9c1E3kv7J5QvEKTJvcIGEjIr+phHBfNnCirosThzwHZNkHs2yse/mUeBq8SIQTlhg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ps-client/-/ps-client-5.2.0.tgz",
+      "integrity": "sha512-hPCSGqmHFPsjHbu/RBC5d/SGDWyScTodxMbHkk0bqikeG1avvVZGP+WrLUCgPEqyU57RWqYQ+i0yfjxMp8SCAA==",
       "license": "ISC",
       "dependencies": {
         "isomorphic-ws": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fast-cartesian": "^9.0.1",
-    "ps-client": "^5.1.2"
+    "ps-client": "^5.2.0"
   },
   "trustedDependencies": [
     "es5-ext"


### PR DESCRIPTION
ps-client changelog (sourced from PartMan's clipboard)


## What's New

**v5.2.0**

- Supports the new `Species#isCosmeticForme` prop on Pokédex Species.
- Fixes some JSDoc default value mismatches. [#37](https://github.com/PartMan7/PS-Client/pull/37) by [@singiamtel](https://github.com/singiamtel)
- Removes the unused dotenv dependency. [#38](https://github.com/PartMan7/PS-Client/pull/38) by [@singiamtel](https://github.com/singiamtel)

**v5.1.2**

- Checks `null` cases for `Client.status` in methods like `Client#send` when the client might be forcefully disconnected.
